### PR TITLE
Set fieldToAvoid to authorizedFields when present.

### DIFF
--- a/src/object-type-registery.js
+++ b/src/object-type-registery.js
@@ -34,6 +34,8 @@ class ObjectTypeRegistery {
         if (objectTypeFields[objectTypeFieldKey] && objectTypeFields[objectTypeFieldKey] && !objectTypeFields[objectTypeFieldKey].secure) {
           newFields[keyField] = fields[keyField]
         }
+      } else {
+        newFields[keyField] = fields[keyField];
       }
     })
 


### PR DESCRIPTION
Able to pass fields that are not in the graphqlObjectType.
Like $parents for example.